### PR TITLE
Initialise diagnostic commercial express

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,67 @@
-# Calculateur-de-conversion-perdue
+# Diagnostic Commercial Express
+
+Mini-module 100 % client-side pour estimer en quelques secondes la performance de votre tunnel commercial et le manque à gagner potentiel. Idéal pour être embarqué dans Notion ou partagé via une simple URL.
+
+![Aperçu à ajouter](docs/screenshot.png)
+
+## Démo
+- Vercel : https://votre-url-a-remplacer.vercel.app
+- GitHub Pages : https://votre-utilisateur.github.io/diagnostic-commercial-express/
+
+> 💡 Remplacez les liens ci-dessus par l'URL réelle de votre déploiement.
+
+## Fonctionnalités
+- Saisie ultra-rapide (leads, devis, signatures, panier moyen).
+- Calcul automatique des taux de conversion, du chiffre d'affaires actuel et du manque à gagner avec +10 pts sur la conversion devis → signatures.
+- Comparaison visuelle à un benchmark fictif.
+- Aucune donnée envoyée côté serveur : tout se passe dans le navigateur.
+- Charte visuelle minimaliste inspirée de Notion pour une intégration harmonieuse dans vos espaces.
+
+## Installer & embarquer dans Notion
+1. Déployez le dossier `/src` sur Vercel ou activez GitHub Pages (voir section Déploiement).
+2. Copiez l'URL publique de la page `index.html` (ex. `https://.../`).
+3. Dans Notion, tapez `/embed`, collez l'URL et validez. Le module s'affiche automatiquement.
+
+## Configuration
+- **Lien CTA** : modifiez l'attribut `data-cta-url` dans `src/index.html` (section `<main>`). Le bouton "Activer mes 3 leviers maintenant" pointera vers cette URL.
+- **Benchmarks** : ajustez les valeurs dans `src/benchmarks.js` pour refléter vos propres moyennes sectorielles.
+
+## Développement
+Aucune étape de build n'est nécessaire : ouvrez simplement `src/index.html` dans votre navigateur.
+
+Structure du projet :
+```
+.
+├─ README.md
+├─ LICENSE
+├─ public/
+│  └─ favicon.svg
+├─ src/
+│  ├─ index.html
+│  ├─ styles.css
+│  ├─ app.js
+│  ├─ benchmarks.js
+│  └─ utils.js
+├─ tests/
+│  └─ app.test.md
+├─ vercel.json
+└─ .editorconfig
+```
+
+### Tests
+Les scénarios de tests manuels se trouvent dans `tests/app.test.md`. Ils couvrent notamment :
+- Valeurs nominales réalistes.
+- Cas limites (0 lead, 0 devis, signatures > devis...).
+- Vérification de la cohérence des badges et du comparatif benchmark.
+
+## Déploiement
+### Vercel
+Le fichier `vercel.json` configure la redirection de toutes les routes vers `src/index.html` et expose le dossier `public/` pour les assets statiques.
+
+### GitHub Pages
+Option 1 : déplacer le contenu de `src/` dans un dossier `docs/` et activer GitHub Pages sur `main` → `/docs`.
+
+Option 2 : configurer une GitHub Action qui copie `src/` vers la branche `gh-pages` (et `public/` à la racine) lors des pushes.
+
+## Licence
+Projet sous licence [MIT](LICENSE). Vous êtes libre de l'utiliser et de l'adapter tant que vous conservez la mention de licence.

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title">
+  <title>Diagnostic Commercial Express</title>
+  <rect width="64" height="64" rx="12" fill="#191919"/>
+  <path d="M18 42l9-12 8 8 11-16" fill="none" stroke="#ffffff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="18" cy="42" r="3" fill="#ffffff"/>
+  <circle cx="27" cy="30" r="3" fill="#ffffff"/>
+  <circle cx="35" cy="38" r="3" fill="#ffffff"/>
+  <circle cx="46" cy="22" r="3" fill="#ffffff"/>
+</svg>

--- a/src/app.js
+++ b/src/app.js
@@ -1,0 +1,229 @@
+import { BENCH } from './benchmarks.js';
+import { clamp, pct, eur, badgeFromRatio } from './utils.js';
+
+const appRoot = document.querySelector('[data-app-root]');
+const form = document.querySelector('#metrics-form');
+
+const fieldWrappers = {};
+const inputs = {};
+const helpTexts = {};
+const helpDefaults = {};
+
+if (form) {
+  form.querySelectorAll('.field[data-field]').forEach((wrapper) => {
+    const key = wrapper.dataset.field;
+    fieldWrappers[key] = wrapper;
+    const input = wrapper.querySelector('input');
+    if (input) {
+      inputs[key] = input;
+    }
+    const help = wrapper.querySelector('.help[data-help-for]');
+    if (help) {
+      const helpKey = help.dataset.helpFor;
+      helpTexts[helpKey] = help;
+      helpDefaults[helpKey] = help.dataset.default || help.textContent || '';
+    }
+  });
+}
+
+const outputs = {
+  leadsRate: document.querySelector('[data-output="leads-rate"]'),
+  devisRate: document.querySelector('[data-output="devis-rate"]'),
+  caActuel: document.querySelector('[data-output="ca-actuel"]'),
+  manque: document.querySelector('[data-output="manque"]')
+};
+
+const badges = {
+  leads: document.querySelector('[data-badge="leads"]'),
+  devis: document.querySelector('[data-badge="devis"]')
+};
+
+const barFills = {
+  leads: {
+    you: document.querySelector('[data-fill="leads-you"]'),
+    bench: document.querySelector('[data-fill="leads-bench"]')
+  },
+  devis: {
+    you: document.querySelector('[data-fill="devis-you"]'),
+    bench: document.querySelector('[data-fill="devis-bench"]')
+  }
+};
+
+const barValues = {
+  leads: {
+    you: document.querySelector('[data-value="leads-you"]'),
+    bench: document.querySelector('[data-value="leads-bench"]')
+  },
+  devis: {
+    you: document.querySelector('[data-value="devis-you"]'),
+    bench: document.querySelector('[data-value="devis-bench"]')
+  }
+};
+
+const cta = document.querySelector('[data-role="cta"]');
+
+if (cta && appRoot?.dataset.ctaUrl) {
+  cta.setAttribute('href', appRoot.dataset.ctaUrl);
+}
+
+function toNumber(value) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : 0;
+}
+
+function readState() {
+  return {
+    leads_mois: toNumber(inputs.leads_mois?.value),
+    devis_mois: toNumber(inputs.devis_mois?.value),
+    signatures_mois: toNumber(inputs.signatures_mois?.value),
+    panier_moyen: toNumber(inputs.panier_moyen?.value)
+  };
+}
+
+function validate(state) {
+  const errors = {};
+
+  if (state.leads_mois < 0) {
+    errors.leads_mois = 'Le nombre de leads doit être supérieur ou égal à 0.';
+  }
+
+  if (state.devis_mois < 0) {
+    errors.devis_mois = 'Le nombre de devis doit être supérieur ou égal à 0.';
+  }
+
+  if (state.signatures_mois < 0) {
+    errors.signatures_mois = 'Les signatures doivent être supérieures ou égales à 0.';
+  } else if (state.signatures_mois > state.devis_mois) {
+    errors.signatures_mois = 'Les signatures ne peuvent pas dépasser les devis.';
+  }
+
+  if (state.panier_moyen < 0) {
+    errors.panier_moyen = 'Le panier moyen doit être positif.';
+  }
+
+  return errors;
+}
+
+function sanitize(state) {
+  const leads = Math.max(0, state.leads_mois);
+  const devis = Math.max(0, state.devis_mois);
+  const signatures = Math.max(0, Math.min(state.signatures_mois, devis));
+  const panier = Math.max(0, state.panier_moyen);
+
+  return { leads, devis, signatures, panier };
+}
+
+function computeMetrics(values) {
+  const tauxLeadsDevis = values.leads > 0 ? values.devis / values.leads : 0;
+  const tauxDevisSign = values.devis > 0 ? values.signatures / values.devis : 0;
+  const caActuel = values.signatures * values.panier;
+  const tauxBoost = clamp(tauxDevisSign + 0.1, 0, 1);
+  const signaturesBoost = Math.round(values.devis * tauxBoost);
+  const caBoost = signaturesBoost * values.panier;
+  const manque = Math.max(caBoost - caActuel, 0);
+
+  return {
+    ...values,
+    tauxLeadsDevis,
+    tauxDevisSign,
+    caActuel,
+    manque,
+    tauxBoost,
+    signaturesBoost,
+    caBoost
+  };
+}
+
+function applyBadge(element, badge) {
+  if (!element || !badge) return;
+  element.textContent = badge.label;
+  element.dataset.tone = badge.tone;
+}
+
+function updateBars(metricKey, value, benchValue) {
+  const fillYou = barFills[metricKey]?.you;
+  const fillBench = barFills[metricKey]?.bench;
+  const valYou = barValues[metricKey]?.you;
+  const valBench = barValues[metricKey]?.bench;
+
+  if (fillYou) {
+    fillYou.style.transform = `scaleX(${clamp(value, 0, 1)})`;
+  }
+
+  if (fillBench) {
+    fillBench.style.transform = `scaleX(${clamp(benchValue, 0, 1)})`;
+  }
+
+  if (valYou) {
+    valYou.textContent = pct(value);
+  }
+
+  if (valBench) {
+    valBench.textContent = pct(benchValue);
+  }
+}
+
+function render(metrics) {
+  if (outputs.leadsRate) {
+    outputs.leadsRate.textContent = pct(metrics.tauxLeadsDevis);
+  }
+  if (outputs.devisRate) {
+    outputs.devisRate.textContent = pct(metrics.tauxDevisSign);
+  }
+  if (outputs.caActuel) {
+    outputs.caActuel.textContent = eur(metrics.caActuel);
+  }
+  if (outputs.manque) {
+    outputs.manque.textContent = eur(metrics.manque);
+  }
+
+  applyBadge(
+    badges.leads,
+    badgeFromRatio(metrics.tauxLeadsDevis, BENCH.moyenne.leads_devis, BENCH.seuil)
+  );
+
+  applyBadge(
+    badges.devis,
+    badgeFromRatio(metrics.tauxDevisSign, BENCH.moyenne.devis_signatures, BENCH.seuil)
+  );
+
+  updateBars('leads', metrics.tauxLeadsDevis, BENCH.moyenne.leads_devis);
+  updateBars('devis', metrics.tauxDevisSign, BENCH.moyenne.devis_signatures);
+}
+
+function displayErrors(errors) {
+  Object.entries(fieldWrappers).forEach(([key, wrapper]) => {
+    const message = errors[key] ?? '';
+    if (message) {
+      wrapper.dataset.state = 'error';
+    } else {
+      delete wrapper.dataset.state;
+    }
+    const help = helpTexts[key];
+    if (help) {
+      help.textContent = message || helpDefaults[key] || '';
+    }
+  });
+}
+
+function update() {
+  const state = readState();
+  const errors = validate(state);
+  displayErrors(errors);
+  const sanitized = sanitize(state);
+  const metrics = computeMetrics(sanitized);
+  render(metrics);
+}
+
+if (form) {
+  form.addEventListener('submit', (event) => {
+    event.preventDefault();
+    update();
+  });
+
+  form.addEventListener('input', () => {
+    update();
+  });
+}
+
+update();

--- a/src/benchmarks.js
+++ b/src/benchmarks.js
@@ -1,0 +1,10 @@
+export const BENCH = {
+  moyenne: {
+    leads_devis: 0.3,
+    devis_signatures: 0.4
+  },
+  seuil: {
+    bas: 0.8,
+    haut: 1.2
+  }
+};

--- a/src/index.html
+++ b/src/index.html
@@ -1,0 +1,183 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Diagnostic Commercial Express</title>
+    <meta
+      name="description"
+      content="Mini-module local-first pour analyser votre tunnel commercial et estimer votre manque à gagner."
+    />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <main class="app" data-app-root data-cta-url="https://example.com">
+      <header class="intro">
+        <p class="eyebrow">Mini-module embarquable</p>
+        <h1>Diagnostic commercial express</h1>
+        <p class="subtitle">
+          Visualisez votre tunnel de conversion et votre potentiel de chiffre d'affaires en moins d'une minute.
+        </p>
+      </header>
+
+      <form id="metrics-form" class="form" novalidate>
+        <fieldset class="form-grid">
+          <legend class="sr-only">Données commerciales mensuelles</legend>
+
+          <div class="field" data-field="leads_mois">
+            <label for="leads_mois">Leads générés ce mois</label>
+            <input
+              type="number"
+              id="leads_mois"
+              name="leads_mois"
+              min="0"
+              step="1"
+              inputmode="numeric"
+              placeholder="0"
+              required
+            />
+            <p class="help" data-help-for="leads_mois" data-default="Nombre de prospects qualifiés.">
+              Nombre de prospects qualifiés.
+            </p>
+          </div>
+
+          <div class="field" data-field="devis_mois">
+            <label for="devis_mois">Devis envoyés</label>
+            <input
+              type="number"
+              id="devis_mois"
+              name="devis_mois"
+              min="0"
+              step="1"
+              inputmode="numeric"
+              placeholder="0"
+              required
+            />
+            <p class="help" data-help-for="devis_mois" data-default="Nombre de devis émis sur la période.">
+              Nombre de devis émis sur la période.
+            </p>
+          </div>
+
+          <div class="field" data-field="signatures_mois">
+            <label for="signatures_mois">Signatures obtenues</label>
+            <input
+              type="number"
+              id="signatures_mois"
+              name="signatures_mois"
+              min="0"
+              step="1"
+              inputmode="numeric"
+              placeholder="0"
+              required
+            />
+            <p
+              class="help"
+              data-help-for="signatures_mois"
+              data-default="Contrats signés (≤ devis)."
+            >
+              Contrats signés (≤ devis).
+            </p>
+          </div>
+
+          <div class="field" data-field="panier_moyen">
+            <label for="panier_moyen">Panier moyen (€)</label>
+            <input
+              type="number"
+              id="panier_moyen"
+              name="panier_moyen"
+              min="0"
+              step="1"
+              inputmode="decimal"
+              placeholder="0"
+              required
+            />
+            <p class="help" data-help-for="panier_moyen" data-default="Valeur moyenne d'une signature en euros.">
+              Valeur moyenne d'une signature en euros.
+            </p>
+          </div>
+        </fieldset>
+
+        <button type="submit" class="button primary">Calculer</button>
+      </form>
+
+      <section class="results" aria-live="polite">
+        <div class="results-grid">
+          <article class="card">
+            <h2>Leads → Devis</h2>
+            <p class="metric" data-output="leads-rate">0,0 %</p>
+            <span class="badge" data-badge="leads" data-tone="muted">Non disponible</span>
+            <p class="note">Part des leads convertis en devis.</p>
+          </article>
+
+          <article class="card">
+            <h2>Devis → Signatures</h2>
+            <p class="metric" data-output="devis-rate">0,0 %</p>
+            <span class="badge" data-badge="devis" data-tone="muted">Non disponible</span>
+            <p class="note">Part des devis qui se concluent en signature.</p>
+          </article>
+
+          <article class="card span-2">
+            <h2>Chiffrage</h2>
+            <div class="numbers">
+              <div>
+                <p class="label">CA actuel</p>
+                <p class="value" data-output="ca-actuel">0&nbsp;€</p>
+              </div>
+              <div>
+                <p class="label">Manque à gagner (+10 pts)</p>
+                <p class="value accent" data-output="manque">0&nbsp;€</p>
+              </div>
+            </div>
+            <p class="note">Scénario : +10 points absolus sur la conversion devis → signatures.</p>
+          </article>
+
+          <article class="card span-2">
+            <h2>Comparatif</h2>
+            <div class="bar-group" data-bar="leads">
+              <p class="bar-title">Leads → Devis</p>
+              <div class="bar-line">
+                <span class="bar-label">Vos taux</span>
+                <div class="bar-track">
+                  <span class="bar-fill you" data-fill="leads-you"></span>
+                </div>
+                <span class="bar-value" data-value="leads-you">0,0 %</span>
+              </div>
+              <div class="bar-line">
+                <span class="bar-label">Moyenne</span>
+                <div class="bar-track">
+                  <span class="bar-fill bench" data-fill="leads-bench"></span>
+                </div>
+                <span class="bar-value" data-value="leads-bench">0,0 %</span>
+              </div>
+            </div>
+
+            <div class="bar-group" data-bar="devis">
+              <p class="bar-title">Devis → Signatures</p>
+              <div class="bar-line">
+                <span class="bar-label">Vos taux</span>
+                <div class="bar-track">
+                  <span class="bar-fill you" data-fill="devis-you"></span>
+                </div>
+                <span class="bar-value" data-value="devis-you">0,0 %</span>
+              </div>
+              <div class="bar-line">
+                <span class="bar-label">Moyenne</span>
+                <div class="bar-track">
+                  <span class="bar-fill bench" data-fill="devis-bench"></span>
+                </div>
+                <span class="bar-value" data-value="devis-bench">0,0 %</span>
+              </div>
+            </div>
+          </article>
+        </div>
+
+        <a class="button ghost" data-role="cta" href="#" rel="noopener">Activer mes 3 leviers maintenant</a>
+      </section>
+
+      <footer class="footer">Local-first. Aucune donnée transmise.</footer>
+    </main>
+
+    <script type="module" src="./app.js"></script>
+  </body>
+</html>

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,0 +1,339 @@
+:root {
+  --bg: #ffffff;
+  --fg: #191919;
+  --muted: #6b7280;
+  --line: #e5e7eb;
+  --accent: #2f3437;
+  --card: #fafafa;
+  --radius: 14px;
+  --shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--fg);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  line-height: 1.5;
+}
+
+body {
+  display: flex;
+  justify-content: center;
+  padding: 24px;
+}
+
+.app {
+  width: min(100%, 720px);
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.intro h1 {
+  margin: 4px 0 8px;
+  font-size: 1.95rem;
+  line-height: 1.2;
+}
+
+.intro .subtitle {
+  color: var(--muted);
+  margin: 0;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: var(--muted);
+  margin: 0 0 4px;
+}
+
+.form {
+  background: var(--card);
+  padding: 24px;
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.form-grid {
+  border: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 16px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+label {
+  font-weight: 600;
+}
+
+input[type='number'] {
+  width: 100%;
+  padding: 12px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: #fff;
+  color: inherit;
+  font-size: 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+input[type='number']:focus-visible {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(47, 52, 55, 0.2);
+  outline: none;
+}
+
+.field[data-state='error'] input[type='number'] {
+  border-color: #ef4444;
+  background: #fef2f2;
+}
+
+.field[data-state='error'] .help {
+  color: #b91c1c;
+}
+
+.help {
+  font-size: 0.85rem;
+  color: var(--muted);
+  margin: 0;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  border-radius: 999px;
+  padding: 12px 20px;
+  font-weight: 600;
+  text-decoration: none;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.button.primary {
+  background: var(--accent);
+  color: #fff;
+  border: none;
+}
+
+.button.primary:hover,
+.button.primary:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 18px rgba(47, 52, 55, 0.2);
+}
+
+.button.primary:focus-visible {
+  outline: none;
+}
+
+.button.ghost {
+  border: 1px solid var(--accent);
+  color: var(--accent);
+  background: transparent;
+  align-self: center;
+  padding-inline: 28px;
+}
+
+.button.ghost:hover,
+.button.ghost:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 18px rgba(47, 52, 55, 0.12);
+  outline: none;
+}
+
+.results {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.results-grid {
+  display: grid;
+  gap: 16px;
+}
+
+.card {
+  background: var(--card);
+  padding: 20px;
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.card h2 {
+  font-size: 1.1rem;
+  margin: 0;
+}
+
+.metric {
+  font-size: 2rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  background: var(--line);
+  color: var(--muted);
+  width: fit-content;
+}
+
+.badge[data-tone='bad'] {
+  background: #fee2e2;
+  color: #b91c1c;
+}
+
+.badge[data-tone='mid'] {
+  background: #e5e7eb;
+  color: var(--accent);
+}
+
+.badge[data-tone='good'] {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.note {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.numbers {
+  display: grid;
+  gap: 16px;
+}
+
+.label {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.value {
+  margin: 4px 0 0;
+  font-size: 1.6rem;
+  font-weight: 600;
+}
+
+.value.accent {
+  color: var(--accent);
+}
+
+.bar-group {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.bar-title {
+  margin: 0 0 4px;
+  font-weight: 600;
+}
+
+.bar-line {
+  display: grid;
+  grid-template-columns: 1fr 4fr auto;
+  align-items: center;
+  gap: 12px;
+}
+
+.bar-label {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.bar-track {
+  position: relative;
+  height: 8px;
+  border-radius: 999px;
+  background: var(--line);
+  overflow: hidden;
+}
+
+.bar-fill {
+  position: absolute;
+  inset: 0;
+  transform-origin: left;
+  transform: scaleX(0);
+  transition: transform 0.25s ease;
+}
+
+.bar-fill.you {
+  background: var(--accent);
+}
+
+.bar-fill.bench {
+  background: rgba(25, 25, 25, 0.2);
+}
+
+.bar-value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}
+
+.footer {
+  text-align: center;
+  font-size: 0.85rem;
+  color: var(--muted);
+  padding-bottom: 24px;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+@media (min-width: 640px) {
+  .form-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .numbers {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .results-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .card.span-2 {
+    grid-column: span 2;
+  }
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,49 @@
+const percentFormatter = new Intl.NumberFormat('fr-FR', {
+  style: 'percent',
+  minimumFractionDigits: 1,
+  maximumFractionDigits: 1
+});
+
+const currencyFormatter = new Intl.NumberFormat('fr-FR', {
+  style: 'currency',
+  currency: 'EUR',
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 0
+});
+
+export function clamp(value, min, max) {
+  if (!Number.isFinite(value)) return min;
+  return Math.min(Math.max(value, min), max);
+}
+
+export function pct(value) {
+  if (!Number.isFinite(value)) {
+    return '0,0 %';
+  }
+  return percentFormatter.format(value);
+}
+
+export function eur(value) {
+  if (!Number.isFinite(value)) {
+    return currencyFormatter.format(0);
+  }
+  return currencyFormatter.format(value);
+}
+
+export function badgeFromRatio(value, reference, seuils) {
+  if (!Number.isFinite(value) || !Number.isFinite(reference) || reference <= 0) {
+    return { label: 'Non disponible', tone: 'muted' };
+  }
+
+  const ratio = value / reference;
+
+  if (ratio < seuils.bas) {
+    return { label: 'En retard', tone: 'bad' };
+  }
+
+  if (ratio > seuils.haut) {
+    return { label: 'Au-dessus', tone: 'good' };
+  }
+
+  return { label: 'Dans la moyenne', tone: 'mid' };
+}

--- a/tests/app.test.md
+++ b/tests/app.test.md
@@ -1,0 +1,45 @@
+# Tests manuels – Diagnostic Commercial Express
+
+## Pré-requis
+- Ouvrir `src/index.html` dans un navigateur moderne (Chrome, Edge, Safari, Firefox).
+- Vider le cache pour s'assurer qu'aucune version précédente n'est conservée.
+
+## Scénario 1 – Parcours nominal
+1. Renseigner `Leads générés` = 250.
+2. Renseigner `Devis envoyés` = 80.
+3. Renseigner `Signatures obtenues` = 28.
+4. Renseigner `Panier moyen` = 3200.
+5. Cliquer sur **Calculer** (ou vérifier que le calcul en direct s'exécute).
+6. Vérifier :
+   - Taux Leads → Devis ≈ `32,0 %` (badge "Au-dessus" attendu car supérieur à 30 %).
+   - Taux Devis → Signatures ≈ `35,0 %` (badge "Dans la moyenne" car proche des 40 % ± 20 %).
+   - CA actuel ≈ `89 600 €`.
+   - Manque à gagner ≈ `25 600 €` (28 → 36 signatures avec +10 pts).
+   - Barres comparatives affichent la valeur utilisateur vs benchmark (barre moyenne à 30 % / 40 %).
+7. Cliquer sur le CTA et confirmer qu'il ouvre l'URL définie dans `data-cta-url` (par défaut `https://example.com`).
+
+## Scénario 2 – Absence de leads
+1. Saisir `Leads générés` = 0, `Devis envoyés` = 0, `Signatures obtenues` = 0, `Panier moyen` = 0.
+2. Vérifier :
+   - Les taux affichent `0,0 %`.
+   - Les badges passent en état "Non disponible" ou "En retard" selon la logique.
+   - Les barres restent vides.
+   - Aucun message d'erreur ne s'affiche.
+
+## Scénario 3 – Validation signatures > devis
+1. Saisir `Leads générés` = 50, `Devis envoyés` = 20, `Signatures obtenues` = 30.
+2. Constater l'apparition du message d'erreur "Les signatures ne peuvent pas dépasser les devis." sous le champ signatures, avec un style rouge.
+3. Ajuster `Signatures obtenues` à 18.
+4. Vérifier que l'erreur disparaît et que les résultats se recalculent automatiquement.
+
+## Scénario 4 – Valeur panier importante
+1. Saisir `Leads générés` = 120, `Devis envoyés` = 36, `Signatures obtenues` = 15, `Panier moyen` = 10500.
+2. Vérifier :
+   - CA actuel ≈ `157 500 €`.
+   - Manque à gagner reflète l'augmentation des signatures (taux à 25 % → +10 pts = 35 % → 13 signatures → +2 signatures ≈ `21 000 €`).
+   - Les barres comparatives restent proportionnelles et limitées à 100 % de largeur.
+
+## Scénario 5 – Accessibilité et responsive
+1. Naviguer au clavier (Tab) : chaque champ et bouton doit afficher un focus visible.
+2. Réduire la fenêtre à une largeur < 480 px : les cartes passent en une colonne, le contenu reste lisible et sans débordement.
+3. Sur écran large (> 1024 px), vérifier que la largeur n'excède pas ~720 px et que le module reste centré.

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "version": 2,
+  "public": "public",
+  "rewrites": [
+    { "source": "/favicon.svg", "destination": "/public/favicon.svg" },
+    { "source": "/", "destination": "/src/index.html" },
+    { "source": "/(.*)", "destination": "/src/index.html" }
+  ]
+}


### PR DESCRIPTION
## Summary
- create the public, src, and tests structure for the Diagnostic Commercial Express mini-app
- implement the vanilla JS calculator with Notion-inspired UI, benchmarks, and CTA configuration
- document manual testing scenarios, deployment notes, and provide MIT licensing plus Vercel routing

## Testing
- not run (client-side module)


------
https://chatgpt.com/codex/tasks/task_e_68ca98acfe1083208682c4028ed8f45e