### PR TITLE
Structure project with Notion inspired theme

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,0 +1,335 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding: var(--space-xl) var(--space-lg);
+}
+
+.app-shell {
+  width: 100%;
+  max-width: var(--layout-max-width);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--color-shadow);
+  overflow: hidden;
+}
+
+.app-header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: var(--space-md);
+  padding: var(--space-lg) var(--space-xl) var(--space-md);
+  background: var(--color-surface-muted);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.app-header h1 {
+  margin: 0;
+  font-size: 1.35rem;
+  font-weight: 600;
+  color: var(--color-heading);
+}
+
+.app-header small {
+  display: block;
+  margin-top: var(--space-2xs);
+  color: var(--color-text-muted);
+}
+
+.app-grid {
+  display: grid;
+  gap: var(--space-lg);
+  padding: 0 var(--space-xl) var(--space-xl);
+}
+
+@media (min-width: 860px) {
+  .app-grid {
+    grid-template-columns: 1.15fr 0.85fr;
+    align-items: start;
+  }
+}
+
+.panel {
+  padding: var(--space-lg);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.4);
+}
+
+.panel h2 {
+  margin: 0 0 var(--space-sm);
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--color-heading);
+}
+
+.form-grid,
+.metrics-grid {
+  display: grid;
+  gap: var(--space-sm);
+}
+
+@media (min-width: 640px) {
+  .form-grid.two {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.input-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2xs);
+}
+
+label {
+  font-weight: 600;
+}
+
+input,
+select {
+  appearance: none;
+  padding: var(--space-sm);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-muted);
+  color: var(--color-text);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+input:focus,
+select:focus {
+  outline: none;
+  border-color: var(--color-accent);
+  box-shadow: var(--focus-ring);
+}
+
+.hint {
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+  margin-top: var(--space-sm);
+}
+
+button {
+  appearance: none;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  padding: var(--space-sm) var(--space-md);
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.18s ease, border-color 0.18s ease;
+}
+
+button:focus-visible,
+.cta a:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+button:active {
+  transform: translateY(1px);
+}
+
+button.primary {
+  background: var(--color-accent);
+  color: #fff;
+  box-shadow: 0 10px 20px rgba(47, 128, 255, 0.2);
+}
+
+button.primary:hover {
+  background: #1d6de8;
+}
+
+button.secondary {
+  background: var(--color-surface);
+  border-color: var(--color-border-strong);
+  color: var(--color-text);
+}
+
+button.secondary:hover {
+  background: var(--color-surface-muted);
+}
+
+.results {
+  display: grid;
+  gap: var(--space-lg);
+}
+
+.kpis {
+  display: grid;
+  gap: var(--space-sm);
+}
+
+@media (min-width: 680px) {
+  .kpis {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.kpi {
+  padding: var(--space-md);
+  border-radius: var(--radius-md);
+  background: var(--color-surface-muted);
+  border: 1px solid var(--color-border);
+}
+
+.kpi .label {
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+}
+
+.kpi .value {
+  margin-top: var(--space-xs);
+  font-size: 1.4rem;
+  font-weight: 700;
+}
+
+.compare {
+  display: grid;
+  gap: var(--space-md);
+}
+
+.compare-row {
+  display: grid;
+  gap: var(--space-sm);
+  align-items: center;
+}
+
+@media (min-width: 540px) {
+  .compare-row {
+    grid-template-columns: 1fr auto;
+    gap: var(--space-md);
+  }
+}
+
+.progress {
+  position: relative;
+  height: 14px;
+  border-radius: var(--radius-pill);
+  background: var(--color-surface-muted);
+  border: 1px solid var(--color-border);
+  overflow: hidden;
+}
+
+.progress > span {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 0;
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--color-negative), var(--color-warning), var(--color-positive));
+  transition: width 0.3s ease;
+}
+
+.progress .target {
+  position: absolute;
+  top: -6px;
+  bottom: -6px;
+  width: 2px;
+  border-radius: 999px;
+  background: var(--color-accent);
+  opacity: 0.7;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-2xs) var(--space-sm);
+  font-size: 0.75rem;
+  font-weight: 600;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--color-border);
+  color: var(--color-text);
+  min-width: 130px;
+  text-align: center;
+}
+
+.pill.ok {
+  background: var(--color-positive-soft);
+  border-color: rgba(15, 123, 108, 0.4);
+  color: var(--color-positive);
+}
+
+.pill.warn {
+  background: var(--color-warning-soft);
+  border-color: rgba(181, 105, 0, 0.4);
+  color: var(--color-warning);
+}
+
+.pill.bad {
+  background: var(--color-negative-soft);
+  border-color: rgba(210, 70, 38, 0.4);
+  color: var(--color-negative);
+}
+
+.cta {
+  display: flex;
+  justify-content: flex-end;
+  padding: 0 var(--space-xl) var(--space-xl);
+}
+
+.cta a {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+  text-decoration: none;
+  font-weight: 700;
+  background: var(--color-positive);
+  color: #fff;
+  padding: var(--space-sm) var(--space-md);
+  border-radius: var(--radius-pill);
+  box-shadow: 0 14px 30px rgba(15, 123, 108, 0.2);
+  transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.18s ease;
+}
+
+.cta a:hover {
+  background: #0d695c;
+}
+
+.cta small {
+  display: block;
+  margin-top: var(--space-2xs);
+  color: var(--color-text-muted);
+  font-size: 0.8rem;
+}
+
+#customRow {
+  display: none;
+}
+
+#customRow.is-visible {
+  display: grid;
+}
+
+@media (max-width: 640px) {
+  body {
+    padding: var(--space-lg) var(--space-sm);
+  }
+
+  .app-header {
+    padding: var(--space-lg) var(--space-lg) var(--space-md);
+  }
+
+  .app-grid {
+    padding: 0 var(--space-lg) var(--space-lg);
+  }
+
+  .cta {
+    padding: 0 var(--space-lg) var(--space-lg);
+  }
+}

--- a/assets/css/theme-notion.css
+++ b/assets/css/theme-notion.css
@@ -1,0 +1,62 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+
+:root {
+  /* Couleurs principales inspirées de l'interface Notion */
+  --color-background: #f7f6f3;
+  --color-surface: #ffffff;
+  --color-surface-muted: #f3f2ed;
+  --color-border: rgba(15, 15, 15, 0.08);
+  --color-border-strong: rgba(15, 15, 15, 0.16);
+  --color-shadow: 0 18px 36px rgba(15, 15, 15, 0.1);
+  --color-text: #2f3437;
+  --color-text-muted: #6d6c6c;
+  --color-heading: #050505;
+  --color-accent: #2f80ff;
+  --color-accent-soft: rgba(47, 128, 255, 0.12);
+  --color-positive: #0f7b6c;
+  --color-positive-soft: rgba(15, 123, 108, 0.12);
+  --color-warning: #b56900;
+  --color-warning-soft: rgba(181, 105, 0, 0.12);
+  --color-negative: #d24626;
+  --color-negative-soft: rgba(210, 70, 38, 0.12);
+
+  /* Typographie */
+  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-size-base: 16px;
+  --line-height-base: 1.5;
+
+  /* Rayons et espacements */
+  --radius-lg: 18px;
+  --radius-md: 12px;
+  --radius-pill: 999px;
+  --space-2xs: 6px;
+  --space-xs: 8px;
+  --space-sm: 12px;
+  --space-md: 16px;
+  --space-lg: 24px;
+  --space-xl: 32px;
+  --layout-max-width: 960px;
+
+  /* Effets */
+  --focus-ring: 0 0 0 3px rgba(47, 128, 255, 0.3);
+}
+
+html {
+  font-size: var(--font-size-base);
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-sans);
+  line-height: var(--line-height-base);
+  color: var(--color-text);
+  background-color: var(--color-background);
+}
+
+a {
+  color: inherit;
+}
+
+button {
+  font-family: inherit;
+}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,0 +1,147 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const formatCurrency = (value) =>
+    Number.isFinite(value)
+      ? value.toLocaleString('fr-FR', {
+          style: 'currency',
+          currency: 'EUR',
+          maximumFractionDigits: 0,
+        })
+      : '—';
+
+  const get = (id) => document.getElementById(id);
+
+  const fieldIds = ['leads', 'devis', 'signatures', 'panier', 'improv', 'secteur', 'benchLD', 'benchDS'];
+
+  const sectorPresets = {
+    indus: { ld: 30, ds: 40 },
+    b2b: { ld: 25, ds: 35 },
+    surmesure: { ld: 20, ds: 30 },
+  };
+
+  const STORAGE_KEY = 'convbench@v1';
+  const CTA_BASE_URL = 'https://cal.com/your-handle/diagnostic';
+  const customRow = get('customRow');
+
+  const clampPercent = (value) => Math.max(0, Math.min(100, value));
+
+  const classify = (value, reference) => {
+    const delta = value - reference;
+    if (delta >= 5) return { cls: 'ok', label: 'Au-dessus' };
+    if (Math.abs(delta) < 5) return { cls: 'warn', label: 'Dans la moyenne' };
+    return { cls: 'bad', label: 'En dessous' };
+  };
+
+  function updateBenchVisibility() {
+    const isCustom = get('secteur').value === 'custom';
+    customRow.classList.toggle('is-visible', isCustom);
+    if (!isCustom) {
+      const preset = sectorPresets[get('secteur').value] || sectorPresets.indus;
+      get('benchLD').value = preset.ld;
+      get('benchDS').value = preset.ds;
+    }
+  }
+
+  function renderPill(elementId, verdict) {
+    const element = get(elementId);
+    element.className = `pill ${verdict.cls}`;
+    element.textContent = verdict.label;
+  }
+
+  function calc() {
+    const leads = Number(get('leads').value) || 0;
+    const devis = Number(get('devis').value) || 0;
+    const signatures = Number(get('signatures').value) || 0;
+    const panier = Number(get('panier').value) || 0;
+    const improvement = Number(get('improv').value) || 0;
+    const benchLD = Number(get('benchLD').value) || 0;
+    const benchDS = Number(get('benchDS').value) || 0;
+
+    const tauxLD = leads > 0 ? (devis / leads) * 100 : 0;
+    const tauxDS = devis > 0 ? (signatures / devis) * 100 : 0;
+
+    const caActuel = signatures * panier;
+    const tauxDSAmeliore = clampPercent(tauxDS + improvement);
+    const caProjete = devis * (tauxDSAmeliore / 100) * panier;
+    const manque = Math.max(0, caProjete - caActuel);
+
+    get('improvShow').textContent = improvement.toFixed(0);
+    get('caActuel').textContent = formatCurrency(caActuel);
+    get('caProjete').textContent = formatCurrency(caProjete);
+    get('manque').textContent = formatCurrency(manque);
+
+    get('barLD').style.width = `${clampPercent(tauxLD)}%`;
+    get('barDS').style.width = `${clampPercent(tauxDS)}%`;
+
+    get('targetLD').style.left = `${clampPercent(benchLD)}%`;
+    get('targetDS').style.left = `${clampPercent(benchDS)}%`;
+
+    get('txtLD').textContent = `Votre taux : ${tauxLD.toFixed(0)}% • Réf : ${benchLD}%`;
+    get('txtDS').textContent = `Votre taux : ${tauxDS.toFixed(0)}% • Réf : ${benchDS}%`;
+
+    renderPill('pillLD', classify(tauxLD, benchLD));
+    renderPill('pillDS', classify(tauxDS, benchDS));
+
+    const params = new URLSearchParams({
+      leads,
+      devis,
+      sign: signatures,
+      panier,
+      tLD: tauxLD.toFixed(0),
+      tDS: tauxDS.toFixed(0),
+      manque: Math.round(manque),
+    });
+    get('ctaLink').href = `${CTA_BASE_URL}?${params.toString()}`;
+  }
+
+  function save() {
+    const payload = Object.fromEntries(fieldIds.map((id) => [id, get(id).value]));
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+    alert('Valeurs mémorisées dans votre navigateur.');
+  }
+
+  function load() {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return;
+    try {
+      const data = JSON.parse(raw);
+      fieldIds.forEach((id) => {
+        if (data[id] !== undefined) {
+          get(id).value = data[id];
+        }
+      });
+    } catch (error) {
+      console.warn('Impossible de charger les valeurs enregistrées', error);
+    }
+  }
+
+  function resetAll() {
+    fieldIds.forEach((id) => {
+      if (id === 'secteur') {
+        get(id).value = 'indus';
+      } else if (id === 'improv') {
+        get(id).value = 10;
+      } else {
+        get(id).value = '';
+      }
+    });
+    updateBenchVisibility();
+    calc();
+  }
+
+  get('calcBtn').addEventListener('click', calc);
+  get('saveBtn').addEventListener('click', save);
+  get('resetBtn').addEventListener('click', resetAll);
+
+  get('secteur').addEventListener('change', () => {
+    updateBenchVisibility();
+    calc();
+  });
+
+  ['leads', 'devis', 'signatures', 'panier', 'improv', 'benchLD', 'benchDS'].forEach((id) => {
+    get(id).addEventListener('input', calc);
+  });
+
+  load();
+  updateBenchVisibility();
+  calc();
+});

--- a/index.html
+++ b/index.html
@@ -1,286 +1,138 @@
 <!DOCTYPE html>
 <html lang="fr">
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Conversion & Benchmark Express</title>
-  <style>
-    :root{
-      --bg:#0b1020;--card:#121a35;--ink:#e9ecf4;--muted:#9aa3b2;--brand:#6ea8fe;--ok:#3ddc84;--warn:#ffd166;--bad:#ff6b6b;--shadow:0 10px 30px rgba(0,0,0,.35);
-      --radius:16px;--pad:14px;--gap:14px;--max:980px
-    }
-    *{box-sizing:border-box}
-    body{margin:0;background:radial-gradient(1200px 600px at 20% -10%,#182246 0%,transparent 50%),
-                      radial-gradient(1000px 500px at 120% 10%,#1b2a5a 0%,transparent 50%),
-                      var(--bg);color:var(--ink);font:16px/1.45 system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial}
-    .wrap{max-width:var(--max);margin:auto;padding:28px}
-    .card{background:var(--card);border:1px solid rgba(255,255,255,.06);border-radius:var(--radius);box-shadow:var(--shadow)}
-    header{display:flex;justify-content:space-between;align-items:center;gap:var(--gap);padding:20px 22px}
-    header h1{font-size:20px;margin:0}
-    header small{color:var(--muted)}
-    .grid{display:grid;grid-template-columns:1fr;gap:var(--gap);padding:0 22px 22px}
-    @media(min-width:860px){.grid{grid-template-columns:1.2fr .8fr}}
-    .panel{padding:20px;border-radius:12px;background:rgba(255,255,255,.02);border:1px solid rgba(255,255,255,.06)}
-    .panel h2{margin:0 0 8px 0;font-size:16px}
-    .row{display:grid;grid-template-columns:1fr 1fr;gap:10px}
-    .input{display:flex;flex-direction:column;gap:6px;margin:10px 0}
-    label{font-weight:600}
-    input,select{background:#0e1430;color:var(--ink);border:1px solid rgba(255,255,255,.08);padding:12px;border-radius:10px;outline:none}
-    input:focus,select:focus{border-color:var(--brand);box-shadow:0 0 0 3px rgba(110,168,254,.25)}
-    .hint{color:var(--muted);font-size:12px}
-    .actions{display:flex;flex-wrap:wrap;gap:10px;margin-top:10px}
-    button{appearance:none;border:0;border-radius:12px;padding:12px 16px;font-weight:700;cursor:pointer}
-    .primary{background:var(--brand);color:#0a0f22}
-    .ghost{background:transparent;color:var(--ink);border:1px solid rgba(255,255,255,.14)}
-
-    /* Results */
-    .results{display:grid;gap:var(--gap)}
-    .kpis{display:grid;grid-template-columns:1fr;gap:var(--gap)}
-    @media(min-width:680px){.kpis{grid-template-columns:repeat(3,1fr)}}
-    .kpi{padding:16px;border-radius:12px;background:rgba(255,255,255,.02);border:1px solid rgba(255,255,255,.06)}
-    .kpi .label{color:var(--muted);font-size:12px}
-    .kpi .value{font-size:22px;font-weight:800;margin-top:6px}
-
-    .bar{position:relative;height:12px;background:#0e1430;border:1px solid rgba(255,255,255,.08);border-radius:999px;overflow:hidden}
-    .bar>span{position:absolute;left:0;top:0;bottom:0;width:0;background:linear-gradient(90deg,var(--bad),var(--warn),var(--ok));transition:width .3s ease}
-    .bar .target{position:absolute;top:-6px;bottom:-6px;width:2px;background:var(--brand);opacity:.8}
-
-    .compare{display:grid;gap:10px}
-    .compare .row2{display:grid;grid-template-columns:1fr auto;align-items:center;gap:10px}
-    .pill{font-weight:700;font-size:12px;padding:6px 10px;border-radius:999px;border:1px solid rgba(255,255,255,.1)}
-    .pill.ok{background:rgba(61,220,132,.12);border-color:rgba(61,220,132,.3);color:#b6ffda}
-    .pill.warn{background:rgba(255,209,102,.12);border-color:rgba(255,209,102,.3);color:#ffe6a6}
-    .pill.bad{background:rgba(255,107,107,.12);border-color:rgba(255,107,107,.3);color:#ffc5c5}
-
-    .cta{display:flex;justify-content:flex-end;padding:0 22px 22px}
-    .cta a{display:inline-flex;align-items:center;gap:8px;text-decoration:none;background:var(--ok);color:#062013;padding:12px 18px;border-radius:12px;font-weight:800}
-    .cta small{display:block;color:var(--muted);margin-top:6px}
-  </style>
-</head>
-<body>
-  <div class="wrap card">
-    <header>
-      <div>
-        <h1>Conversion & Benchmark Express</h1>
-        <small>En 60 secondes : votre manque à gagner et vos priorités.</small>
-      </div>
-      <button class="ghost" id="resetBtn" title="Réinitialiser">↺ Réinitialiser</button>
-    </header>
-
-    <section class="grid">
-      <!-- Inputs -->
-      <div class="panel">
-        <h2>1) Données (mensuelles)</h2>
-        <div class="row">
-          <div class="input">
-            <label for="leads">Leads entrants</label>
-            <input id="leads" type="number" min="0" step="1" placeholder="ex. 120" />
-            <div class="hint">Formulaires, appels, emails…</div>
-          </div>
-          <div class="input">
-            <label for="devis">Devis envoyés</label>
-            <input id="devis" type="number" min="0" step="1" placeholder="ex. 60" />
-          </div>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Conversion & Benchmark Express</title>
+    <link rel="stylesheet" href="assets/css/theme-notion.css" />
+    <link rel="stylesheet" href="assets/css/main.css" />
+  </head>
+  <body>
+    <div class="app-shell">
+      <header class="app-header">
+        <div>
+          <h1>Conversion &amp; Benchmark Express</h1>
+          <small>En 60 secondes : votre manque à gagner et vos priorités.</small>
         </div>
-        <div class="row">
-          <div class="input">
-            <label for="signatures">Signatures</label>
-            <input id="signatures" type="number" min="0" step="1" placeholder="ex. 18" />
-          </div>
-          <div class="input">
-            <label for="panier">Panier moyen (€)</label>
-            <input id="panier" type="number" min="0" step="50" placeholder="ex. 4500" />
-          </div>
-        </div>
-        <div class="row">
-          <div class="input">
-            <label for="improv">Amélioration visée (points de %)</label>
-            <input id="improv" type="number" min="0" max="100" step="1" value="10" />
-            <div class="hint">Appliquée au taux Devis → Signatures</div>
-          </div>
-          <div class="input">
-            <label for="secteur">Référence secteur</label>
-            <select id="secteur">
-              <option value="indus">Industrie (30% / 40%)</option>
-              <option value="b2b">B2B services (25% / 35%)</option>
-              <option value="surmesure">Projets sur-mesure (20% / 30%)</option>
-              <option value="custom">Personnalisé…</option>
-            </select>
-            <div class="hint">Format : Leads→Devis / Devis→Signatures</div>
-          </div>
-        </div>
-        <div class="row" id="customRow" style="display:none">
-          <div class="input">
-            <label for="benchLD">Réf. Leads→Devis (%)</label>
-            <input id="benchLD" type="number" min="0" max="100" step="1" value="30" />
-          </div>
-          <div class="input">
-            <label for="benchDS">Réf. Devis→Signatures (%)</label>
-            <input id="benchDS" type="number" min="0" max="100" step="1" value="40" />
-          </div>
-        </div>
-        <div class="actions">
-          <button class="primary" id="calcBtn">Calculer</button>
-          <button class="ghost" id="saveBtn">💾 Mémoriser</button>
-        </div>
-      </div>
+        <button class="secondary" type="button" id="resetBtn" title="Réinitialiser">↺ Réinitialiser</button>
+      </header>
 
-      <!-- Results -->
-      <div class="panel">
-        <h2>2) Résultats</h2>
-        <div class="results">
-          <div class="kpis">
-            <div class="kpi">
-              <div class="label">CA actuel (estimé)</div>
-              <div class="value" id="caActuel">—</div>
+      <section class="app-grid">
+        <div class="panel" aria-labelledby="inputs-title">
+          <h2 id="inputs-title">1) Données (mensuelles)</h2>
+          <div class="form-grid two">
+            <div class="input-field">
+              <label for="leads">Leads entrants</label>
+              <input id="leads" type="number" min="0" step="1" placeholder="ex. 120" />
+              <span class="hint">Formulaires, appels, emails…</span>
             </div>
-            <div class="kpi">
-              <div class="label">CA projeté (+<span id="improvShow">10</span> pts)</div>
-              <div class="value" id="caProjete">—</div>
-            </div>
-            <div class="kpi">
-              <div class="label">Manque à gagner mensuel</div>
-              <div class="value" id="manque">—</div>
+            <div class="input-field">
+              <label for="devis">Devis envoyés</label>
+              <input id="devis" type="number" min="0" step="1" placeholder="ex. 60" />
             </div>
           </div>
 
-          <div class="compare">
-            <div class="row2">
-              <div>
-                <strong>Taux Leads → Devis</strong>
-                <div class="bar" aria-label="Taux Leads vers Devis">
-                  <span id="barLD"></span>
-                  <i class="target" id="targetLD" title="Référence secteur"></i>
+          <div class="form-grid two">
+            <div class="input-field">
+              <label for="signatures">Signatures</label>
+              <input id="signatures" type="number" min="0" step="1" placeholder="ex. 18" />
+            </div>
+            <div class="input-field">
+              <label for="panier">Panier moyen (€)</label>
+              <input id="panier" type="number" min="0" step="50" placeholder="ex. 4500" />
+            </div>
+          </div>
+
+          <div class="form-grid two">
+            <div class="input-field">
+              <label for="improv">Amélioration visée (points de %)</label>
+              <input id="improv" type="number" min="0" max="100" step="1" value="10" />
+              <span class="hint">Appliquée au taux Devis → Signatures</span>
+            </div>
+            <div class="input-field">
+              <label for="secteur">Référence secteur</label>
+              <select id="secteur">
+                <option value="indus">Industrie (30% / 40%)</option>
+                <option value="b2b">B2B services (25% / 35%)</option>
+                <option value="surmesure">Projets sur-mesure (20% / 30%)</option>
+                <option value="custom">Personnalisé…</option>
+              </select>
+              <span class="hint">Format : Leads→Devis / Devis→Signatures</span>
+            </div>
+          </div>
+
+          <div class="form-grid two" id="customRow">
+            <div class="input-field">
+              <label for="benchLD">Réf. Leads→Devis (%)</label>
+              <input id="benchLD" type="number" min="0" max="100" step="1" value="30" />
+            </div>
+            <div class="input-field">
+              <label for="benchDS">Réf. Devis→Signatures (%)</label>
+              <input id="benchDS" type="number" min="0" max="100" step="1" value="40" />
+            </div>
+          </div>
+
+          <div class="actions">
+            <button class="primary" type="button" id="calcBtn">Calculer</button>
+            <button class="secondary" type="button" id="saveBtn">💾 Mémoriser</button>
+          </div>
+        </div>
+
+        <div class="panel" aria-labelledby="results-title">
+          <h2 id="results-title">2) Résultats</h2>
+          <div class="results">
+            <div class="kpis">
+              <article class="kpi">
+                <div class="label">CA actuel (estimé)</div>
+                <div class="value" id="caActuel">—</div>
+              </article>
+              <article class="kpi">
+                <div class="label">CA projeté (+<span id="improvShow">10</span> pts)</div>
+                <div class="value" id="caProjete">—</div>
+              </article>
+              <article class="kpi">
+                <div class="label">Manque à gagner mensuel</div>
+                <div class="value" id="manque">—</div>
+              </article>
+            </div>
+
+            <div class="compare">
+              <div class="compare-row">
+                <div>
+                  <strong>Taux Leads → Devis</strong>
+                  <div class="progress" aria-label="Taux Leads vers Devis">
+                    <span id="barLD"></span>
+                    <span class="target" id="targetLD" title="Référence secteur"></span>
+                  </div>
+                  <small id="txtLD" class="hint">—</small>
                 </div>
-                <small id="txtLD" class="hint">—</small>
+                <span id="pillLD" class="pill">—</span>
               </div>
-              <span id="pillLD" class="pill">—</span>
-            </div>
 
-            <div class="row2">
-              <div>
-                <strong>Taux Devis → Signatures</strong>
-                <div class="bar" aria-label="Taux Devis vers Signatures">
-                  <span id="barDS"></span>
-                  <i class="target" id="targetDS" title="Référence secteur"></i>
+              <div class="compare-row">
+                <div>
+                  <strong>Taux Devis → Signatures</strong>
+                  <div class="progress" aria-label="Taux Devis vers Signatures">
+                    <span id="barDS"></span>
+                    <span class="target" id="targetDS" title="Référence secteur"></span>
+                  </div>
+                  <small id="txtDS" class="hint">—</small>
                 </div>
-                <small id="txtDS" class="hint">—</small>
+                <span id="pillDS" class="pill">—</span>
               </div>
-              <span id="pillDS" class="pill">—</span>
             </div>
           </div>
         </div>
-      </div>
-    </section>
+      </section>
 
-    <div class="cta">
-      <div>
-        <a id="ctaLink" href="#" target="_blank" rel="noopener">Prendre RDV pour activer ces leviers →</a>
-        <small>Astuce : intégrez ce module via /embed (GitHub Pages ou équivalent). Aucune donnée n’est envoyée côté serveur.</small>
+      <div class="cta">
+        <div>
+          <a id="ctaLink" href="#" target="_blank" rel="noopener">Prendre RDV pour activer ces leviers →</a>
+          <small>Astuce : intégrez ce module via /embed (GitHub Pages ou équivalent). Aucune donnée n’est envoyée côté serveur.</small>
+        </div>
       </div>
     </div>
-  </div>
 
-  <script>
-    const € = (n)=> isFinite(n) ? n.toLocaleString('fr-FR',{style:'currency',currency:'EUR',maximumFractionDigits:0}) : '—';
-    const pct = (n)=> isFinite(n) ? (n*100).toFixed(0)+'%' : '—';
-
-    const el = (id)=> document.getElementById(id);
-    const inputs = ['leads','devis','signatures','panier','improv','secteur','benchLD','benchDS'];
-
-    const presets = {
-      indus:{ld:30, ds:40},
-      b2b:{ld:25, ds:35},
-      surmesure:{ld:20, ds:30}
-    };
-
-    function updateBenchVisibility(){
-      const isCustom = el('secteur').value==='custom';
-      el('customRow').style.display = isCustom? 'grid':'none';
-      if(!isCustom){
-        const p = presets[el('secteur').value] || presets.indus;
-        el('benchLD').value = p.ld; el('benchDS').value = p.ds;
-      }
-    }
-
-    function classify(value, ref){
-      const diff = value - ref; // points
-      if (diff >= 5) return {cls:'ok', label:'Au-dessus'};
-      if (Math.abs(diff) < 5) return {cls:'warn', label:'Dans la moyenne'};
-      return {cls:'bad', label:'En dessous'};
-    }
-
-    function calc(){
-      const leads = +el('leads').value || 0;
-      const devis = +el('devis').value || 0;
-      const sign  = +el('signatures').value || 0;
-      const panier= +el('panier').value || 0;
-      const improv= +el('improv').value || 0; // points
-      const benchLD = +el('benchLD').value || 0;
-      const benchDS = +el('benchDS').value || 0;
-
-      // Taux
-      const tLD = leads>0 ? (devis/leads)*100 : 0;
-      const tDS = devis>0 ? (sign/devis)*100 : 0;
-
-      // CA
-      const caActuel = sign * panier;
-      const tDSplus = Math.min(100, tDS + improv);
-      const caProjete = devis * (tDSplus/100) * panier;
-      const manque = Math.max(0, caProjete - caActuel);
-
-      // KPIs
-      el('improvShow').textContent = improv.toFixed(0);
-      el('caActuel').textContent = €(caActuel);
-      el('caProjete').textContent = €(caProjete);
-      el('manque').textContent = €(manque);
-
-      // Bars
-      el('barLD').style.width = Math.max(0, Math.min(tLD,100)) + '%';
-      el('barDS').style.width = Math.max(0, Math.min(tDS,100)) + '%';
-
-      // Targets position
-      el('targetLD').style.left = Math.max(0, Math.min(benchLD,100)) + '%';
-      el('targetDS').style.left = Math.max(0, Math.min(benchDS,100)) + '%';
-
-      // Texts
-      el('txtLD').textContent = `Votre taux : ${tLD.toFixed(0)}% • Réf : ${benchLD}%`;
-      el('txtDS').textContent = `Votre taux : ${tDS.toFixed(0)}% • Réf : ${benchDS}%`;
-
-      // Pills
-      const a = classify(tLD, benchLD);
-      const b = classify(tDS, benchDS);
-      el('pillLD').className = 'pill ' + a.cls; el('pillLD').textContent = a.label;
-      el('pillDS').className = 'pill ' + b.cls; el('pillDS').textContent = b.label;
-
-      // Update CTA deep-link with query params (for analytics/CRM prefill if utile)
-      const q = new URLSearchParams({leads, devis, sign, panier, tLD: tLD.toFixed(0), tDS: tDS.toFixed(0), manque: Math.round(manque)}).toString();
-      el('ctaLink').href = `https://cal.com/your-handle/diagnostic?${q}`;
-    }
-
-    function save(){
-      const data = Object.fromEntries(inputs.map(id=>[id, el(id).value]));
-      localStorage.setItem('convbench@v1', JSON.stringify(data));
-      alert('Valeurs mémorisées dans votre navigateur.');
-    }
-    function load(){
-      const raw = localStorage.getItem('convbench@v1');
-      if(!raw) return;
-      try{ const data = JSON.parse(raw); inputs.forEach(id=>{ if(data[id]!==undefined) el(id).value = data[id]; }); }catch(e){}
-    }
-    function resetAll(){ inputs.forEach(id=> el(id).value = ''); el('improv').value = 10; el('secteur').value='indus'; updateBenchVisibility(); calc(); }
-
-    // Events
-    el('calcBtn').addEventListener('click', calc);
-    el('saveBtn').addEventListener('click', save);
-    el('resetBtn').addEventListener('click', resetAll);
-    el('secteur').addEventListener('change', ()=>{updateBenchVisibility();});
-    ;['leads','devis','signatures','panier','improv','benchLD','benchDS'].forEach(id=> el(id).addEventListener('input', ()=>{ if(id!=='improv'){} }));
-
-    // Init
-    load();
-    updateBenchVisibility();
-    calc();
-  </script>
-</body>
+    <script src="assets/js/app.js" defer></script>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- restructure the single-page app to load styles and scripts from a clearer project architecture
- add a dedicated Notion-inspired graphic charter and complementary layout stylesheet
- move the calculator logic to an external script and improve event handling and persistence hooks

## Testing
- no automated tests (static frontend project)


------
https://chatgpt.com/codex/tasks/task_e_68ca9e42c3588320ac6dcd9f1e141577