### PR TITLE
Remove CTA appointment prompt from footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,12 +125,6 @@
         </div>
       </section>
 
-      <div class="cta">
-        <div>
-          <a id="ctaLink" href="#" target="_blank" rel="noopener">Prendre RDV pour activer ces leviers →</a>
-          <small>Astuce : intégrez ce module via /embed (GitHub Pages ou équivalent). Aucune donnée n’est envoyée côté serveur.</small>
-        </div>
-      </div>
     </div>
 
     <script src="assets/js/app.js" defer></script>


### PR DESCRIPTION
## Summary
- remove the CTA block that linked to booking an appointment

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ca9f7f9b048320895ff25a6809f004