### PR TITLE
Met à jour les références secteurs

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -12,13 +12,31 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const fieldIds = ['leads', 'devis', 'signatures', 'panier', 'improv', 'secteur', 'benchLD', 'benchDS'];
 
+  const DEFAULT_SECTOR = 'chauffage';
+
   const sectorPresets = {
-    indus: { ld: 30, ds: 40 },
-    b2b: { ld: 25, ds: 35 },
-    surmesure: { ld: 20, ds: 30 },
+    chauffage: { ld: 34, ds: 42 },
+    'constructeurs-bois': { ld: 29, ds: 35 },
+    'equipements-industriels': { ld: 31, ds: 37 },
+    'materiaux-ecologiques': { ld: 27, ds: 34 },
+    'equipements-artisanat-batiment': { ld: 36, ds: 39 },
+    'equipements-electromenagers': { ld: 38, ds: 44 },
+    'mobilier-haut-de-gamme': { ld: 24, ds: 31 },
+    'piscines-spas': { ld: 23, ds: 29 },
+    'revetements-sol': { ld: 33, ds: 38 },
+    'systemes-securite': { ld: 37, ds: 41 },
+    'peintures-revetements-industriels': { ld: 30, ds: 36 },
+    'machines-outils': { ld: 26, ds: 33 },
+    'materiel-electrique': { ld: 35, ds: 40 },
+    'solutions-domotiques': { ld: 28, ds: 34 },
+    'ventilation-climatisation': { ld: 32, ds: 37 },
+    'charpentes-metalliques': { ld: 25, ds: 32 },
+    'materiel-agroalimentaire': { ld: 29, ds: 38 },
+    'logistique-industrielle': { ld: 27, ds: 35 },
+    'emballages-techniques': { ld: 34, ds: 39 },
   };
 
-  const STORAGE_KEY = 'convbench@v1';
+  const STORAGE_KEY = 'convbench@v2';
   const CTA_BASE_URL = 'https://cal.com/your-handle/diagnostic';
   const customRow = get('customRow');
 
@@ -31,11 +49,20 @@ document.addEventListener('DOMContentLoaded', () => {
     return { cls: 'bad', label: 'En dessous' };
   };
 
+  function normalizeSectorValue() {
+    const select = get('secteur');
+    if (select.value !== 'custom' && !sectorPresets[select.value]) {
+      select.value = DEFAULT_SECTOR;
+    }
+  }
+
   function updateBenchVisibility() {
-    const isCustom = get('secteur').value === 'custom';
+    normalizeSectorValue();
+    const selected = get('secteur').value;
+    const isCustom = selected === 'custom';
     customRow.classList.toggle('is-visible', isCustom);
     if (!isCustom) {
-      const preset = sectorPresets[get('secteur').value] || sectorPresets.indus;
+      const preset = sectorPresets[selected] || sectorPresets[DEFAULT_SECTOR];
       get('benchLD').value = preset.ld;
       get('benchDS').value = preset.ds;
     }
@@ -117,7 +144,7 @@ document.addEventListener('DOMContentLoaded', () => {
   function resetAll() {
     fieldIds.forEach((id) => {
       if (id === 'secteur') {
-        get(id).value = 'indus';
+        get(id).value = DEFAULT_SECTOR;
       } else if (id === 'improv') {
         get(id).value = 10;
       } else {

--- a/index.html
+++ b/index.html
@@ -52,9 +52,25 @@
             <div class="input-field">
               <label for="secteur">Référence secteur</label>
               <select id="secteur">
-                <option value="indus">Industrie (30% / 40%)</option>
-                <option value="b2b">B2B services (25% / 35%)</option>
-                <option value="surmesure">Projets sur-mesure (20% / 30%)</option>
+                <option value="chauffage">Matériel de chauffage (34% / 42%)</option>
+                <option value="constructeurs-bois">Constructeurs bois (29% / 35%)</option>
+                <option value="equipements-industriels">Équipements industriels (31% / 37%)</option>
+                <option value="materiaux-ecologiques">Matériaux écologiques (27% / 34%)</option>
+                <option value="equipements-artisanat-batiment">Équipements pour l’artisanat et le bâtiment (36% / 39%)</option>
+                <option value="equipements-electromenagers">Équipements électroménagers (38% / 44%)</option>
+                <option value="mobilier-haut-de-gamme">Mobilier haut de gamme (24% / 31%)</option>
+                <option value="piscines-spas">Piscines et spas (23% / 29%)</option>
+                <option value="revetements-sol">Revêtements de sol (33% / 38%)</option>
+                <option value="systemes-securite">Systèmes de sécurité (37% / 41%)</option>
+                <option value="peintures-revetements-industriels">Peintures et revêtements industriels (30% / 36%)</option>
+                <option value="machines-outils">Machines-outils (26% / 33%)</option>
+                <option value="materiel-electrique">Matériel électrique (35% / 40%)</option>
+                <option value="solutions-domotiques">Solutions domotiques (28% / 34%)</option>
+                <option value="ventilation-climatisation">Ventilation et climatisation (32% / 37%)</option>
+                <option value="charpentes-metalliques">Charpentes métalliques (25% / 32%)</option>
+                <option value="materiel-agroalimentaire">Matériel pour l’agroalimentaire (29% / 38%)</option>
+                <option value="logistique-industrielle">Logistique industrielle (27% / 35%)</option>
+                <option value="emballages-techniques">Emballages techniques (34% / 39%)</option>
                 <option value="custom">Personnalisé…</option>
               </select>
               <span class="hint">Format : Leads→Devis / Devis→Signatures</span>
@@ -64,11 +80,11 @@
           <div class="form-grid two" id="customRow">
             <div class="input-field">
               <label for="benchLD">Réf. Leads→Devis (%)</label>
-              <input id="benchLD" type="number" min="0" max="100" step="1" value="30" />
+              <input id="benchLD" type="number" min="0" max="100" step="1" value="34" />
             </div>
             <div class="input-field">
               <label for="benchDS">Réf. Devis→Signatures (%)</label>
-              <input id="benchDS" type="number" min="0" max="100" step="1" value="40" />
+              <input id="benchDS" type="number" min="0" max="100" step="1" value="42" />
             </div>
           </div>
 


### PR DESCRIPTION
## Summary
- remplace les anciennes références de secteurs par une liste de 19 segments industriels avec leurs taux cibles
- aligne les valeurs par défaut du benchmark et la logique de sélection sur les nouveaux secteurs tout en gérant les données enregistrées

## Testing
- Not run (non applicable)


------
https://chatgpt.com/codex/tasks/task_e_68caa0ad1d8483208a91d1ebb26951ff