### PR TITLE
Adapte le thème à la charte sombre de Notion

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -61,7 +61,7 @@ body {
   border-radius: var(--radius-md);
   background: var(--color-surface);
   border: 1px solid var(--color-border);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.4);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
 }
 
 .panel h2 {
@@ -146,11 +146,11 @@ button:active {
 button.primary {
   background: var(--color-accent);
   color: #fff;
-  box-shadow: 0 10px 20px rgba(47, 128, 255, 0.2);
+  box-shadow: 0 10px 20px rgba(76, 143, 255, 0.25);
 }
 
 button.primary:hover {
-  background: #1d6de8;
+  background: var(--color-accent-hover);
 }
 
 button.secondary {
@@ -261,19 +261,19 @@ button.secondary:hover {
 
 .pill.ok {
   background: var(--color-positive-soft);
-  border-color: rgba(15, 123, 108, 0.4);
+  border-color: rgba(76, 195, 138, 0.4);
   color: var(--color-positive);
 }
 
 .pill.warn {
   background: var(--color-warning-soft);
-  border-color: rgba(181, 105, 0, 0.4);
+  border-color: rgba(245, 165, 36, 0.4);
   color: var(--color-warning);
 }
 
 .pill.bad {
   background: var(--color-negative-soft);
-  border-color: rgba(210, 70, 38, 0.4);
+  border-color: rgba(241, 118, 93, 0.4);
   color: var(--color-negative);
 }
 
@@ -293,12 +293,12 @@ button.secondary:hover {
   color: #fff;
   padding: var(--space-sm) var(--space-md);
   border-radius: var(--radius-pill);
-  box-shadow: 0 14px 30px rgba(15, 123, 108, 0.2);
+  box-shadow: 0 14px 30px rgba(76, 195, 138, 0.25);
   transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.18s ease;
 }
 
 .cta a:hover {
-  background: #0d695c;
+  background: var(--color-positive-hover);
 }
 
 .cta small {

--- a/assets/css/theme-notion.css
+++ b/assets/css/theme-notion.css
@@ -1,24 +1,26 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
 
 :root {
-  /* Couleurs principales inspirées de l'interface Notion */
-  --color-background: #f7f6f3;
-  --color-surface: #ffffff;
-  --color-surface-muted: #f3f2ed;
-  --color-border: rgba(15, 15, 15, 0.08);
-  --color-border-strong: rgba(15, 15, 15, 0.16);
-  --color-shadow: 0 18px 36px rgba(15, 15, 15, 0.1);
-  --color-text: #2f3437;
-  --color-text-muted: #6d6c6c;
-  --color-heading: #050505;
-  --color-accent: #2f80ff;
-  --color-accent-soft: rgba(47, 128, 255, 0.12);
-  --color-positive: #0f7b6c;
-  --color-positive-soft: rgba(15, 123, 108, 0.12);
-  --color-warning: #b56900;
-  --color-warning-soft: rgba(181, 105, 0, 0.12);
-  --color-negative: #d24626;
-  --color-negative-soft: rgba(210, 70, 38, 0.12);
+  /* Palette sombre alignée avec la charte graphique de Notion */
+  --color-background: #191919;
+  --color-surface: #202123;
+  --color-surface-muted: #2f3437;
+  --color-border: rgba(255, 255, 255, 0.06);
+  --color-border-strong: rgba(255, 255, 255, 0.12);
+  --color-shadow: 0 24px 48px rgba(0, 0, 0, 0.6);
+  --color-text: #f7f6f3;
+  --color-text-muted: rgba(247, 246, 243, 0.64);
+  --color-heading: #ffffff;
+  --color-accent: #4c8fff;
+  --color-accent-hover: #6a9dff;
+  --color-accent-soft: rgba(76, 143, 255, 0.18);
+  --color-positive: #4cc38a;
+  --color-positive-hover: #3da97a;
+  --color-positive-soft: rgba(76, 195, 138, 0.18);
+  --color-warning: #f5a524;
+  --color-warning-soft: rgba(245, 165, 36, 0.2);
+  --color-negative: #f1765d;
+  --color-negative-soft: rgba(241, 118, 93, 0.2);
 
   /* Typographie */
   --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
@@ -38,7 +40,7 @@
   --layout-max-width: 960px;
 
   /* Effets */
-  --focus-ring: 0 0 0 3px rgba(47, 128, 255, 0.3);
+  --focus-ring: 0 0 0 3px rgba(76, 143, 255, 0.45);
 }
 
 html {


### PR DESCRIPTION
## Summary
- ajuste la palette de variables CSS pour refléter la charte sombre de Notion
- harmonise les effets de survol et d'ombre des boutons et panneaux avec la nouvelle palette

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68caa18cdce08320ba0dadb5c8337233