### PR TITLE
Calcul automatique et retrait du bouton Calculer

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -123,6 +123,10 @@ select:focus {
   margin-top: var(--space-sm);
 }
 
+.actions-note {
+  flex-basis: 100%;
+}
+
 button {
   appearance: none;
   border: 1px solid transparent;

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -128,7 +128,6 @@ document.addEventListener('DOMContentLoaded', () => {
     calc();
   }
 
-  get('calcBtn').addEventListener('click', calc);
   get('saveBtn').addEventListener('click', save);
   get('resetBtn').addEventListener('click', resetAll);
 

--- a/index.html
+++ b/index.html
@@ -73,8 +73,8 @@
           </div>
 
           <div class="actions">
-            <button class="primary" type="button" id="calcBtn">Calculer</button>
             <button class="secondary" type="button" id="saveBtn">💾 Mémoriser</button>
+            <span class="hint actions-note">Les résultats se mettent à jour automatiquement.</span>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- retire le bouton manuel "Calculer" au profit d’un calcul réactif dès la saisie
- affiche une mention expliquant la mise à jour automatique et ajuste la mise en page
- supprime l’écouteur JavaScript du bouton supprimé

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68caa1dd1be8832098eae127dcc2ab74