### PR TITLE
Enable automatic persistence of calculator inputs

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -96,7 +96,6 @@ document.addEventListener('DOMContentLoaded', () => {
   function save() {
     const payload = Object.fromEntries(fieldIds.map((id) => [id, get(id).value]));
     localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
-    alert('Valeurs mémorisées dans votre navigateur.');
   }
 
   function load() {
@@ -126,19 +125,26 @@ document.addEventListener('DOMContentLoaded', () => {
     });
     updateBenchVisibility();
     calc();
+    save();
   }
 
-  get('calcBtn').addEventListener('click', calc);
-  get('saveBtn').addEventListener('click', save);
+  get('calcBtn').addEventListener('click', () => {
+    calc();
+    save();
+  });
   get('resetBtn').addEventListener('click', resetAll);
 
   get('secteur').addEventListener('change', () => {
     updateBenchVisibility();
     calc();
+    save();
   });
 
   ['leads', 'devis', 'signatures', 'panier', 'improv', 'benchLD', 'benchDS'].forEach((id) => {
-    get(id).addEventListener('input', calc);
+    get(id).addEventListener('input', () => {
+      calc();
+      save();
+    });
   });
 
   load();

--- a/index.html
+++ b/index.html
@@ -74,7 +74,6 @@
 
           <div class="actions">
             <button class="primary" type="button" id="calcBtn">Calculer</button>
-            <button class="secondary" type="button" id="saveBtn">💾 Mémoriser</button>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- persist form values to localStorage automatically on input, sector change, reset, or manual calculation
- remove the manual "Mémoriser" button from the interface since saving is now implicit

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68caa1df2c5c8320a96b9fcacb5b330c