### PR TITLE
Arrondir les résultats et éviter les débordements

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -201,6 +201,12 @@ button.secondary:hover {
   margin-top: var(--space-xs);
   font-size: 1.4rem;
   font-weight: 700;
+  line-height: 1.2;
+  overflow-wrap: anywhere;
+}
+
+.kpi .value.is-compact {
+  font-size: 1.2rem;
 }
 
 .compare {


### PR DESCRIPTION
## Summary
- normalise les espaces générés par Intl.NumberFormat et ajoute un format compact pour les montants élevés
- applique l’affichage compact uniquement pour les valeurs volumineuses tout en conservant l’estimation précise en info-bulle
- ajuste le style des valeurs KPI afin d’éviter les débordements visuels et de prendre en charge le mode compact

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68caa5667fd88320a4fb80eb5d38479f