### PR TITLE
Arrondir les montants en k€ et M€

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -201,6 +201,12 @@ button.secondary:hover {
   margin-top: var(--space-xs);
   font-size: 1.4rem;
   font-weight: 700;
+  line-height: 1.2;
+  overflow-wrap: anywhere;
+}
+
+.kpi .value.is-compact {
+  font-size: 1.2rem;
 }
 
 .compare {


### PR DESCRIPTION
## Summary
- reformate les montants supérieurs à 1 000 € en valeurs arrondies avec un suffixe k€/M€/Md€
- conserve la valeur complète en info-bulle pour préserver la précision lorsqu’on survole les KPI

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68caa5667fd88320a4fb80eb5d38479f