### PR TITLE
Remove memorize button and hint

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -116,17 +116,6 @@ select:focus {
   color: var(--color-text-muted);
 }
 
-.actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-sm);
-  margin-top: var(--space-sm);
-}
-
-.actions-note {
-  flex-basis: 100%;
-}
-
 button {
   appearance: none;
   border: 1px solid transparent;

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -241,7 +241,10 @@ document.addEventListener('DOMContentLoaded', () => {
     calc();
   }
 
-  get('saveBtn').addEventListener('click', save);
+  const saveBtn = get('saveBtn');
+  if (saveBtn) {
+    saveBtn.addEventListener('click', save);
+  }
   get('resetBtn').addEventListener('click', resetAll);
 
   get('secteur').addEventListener('change', () => {

--- a/index.html
+++ b/index.html
@@ -88,10 +88,6 @@
             </div>
           </div>
 
-          <div class="actions">
-            <button class="secondary" type="button" id="saveBtn">💾 Mémoriser</button>
-            <span class="hint actions-note">Les résultats se mettent à jour automatiquement.</span>
-          </div>
         </div>
 
         <div class="panel" aria-labelledby="results-title">


### PR DESCRIPTION
## Summary
- remove the memorize button and auto-update hint from the input panel
- guard the save button handler so the app works without the control
- delete the unused action styles linked to the removed UI

## Testing
- not run (static assets only)


------
https://chatgpt.com/codex/tasks/task_e_68caa8a836f88320ac002497c2a0bec3