### PR TITLE
Arrondir les résultats financiers en unités compactes

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -199,14 +199,15 @@ button.secondary:hover {
 
 .kpi .value {
   margin-top: var(--space-xs);
-  font-size: 1.4rem;
+  font-size: clamp(1.1rem, 1rem + 0.6vw, 1.4rem);
   font-weight: 700;
   line-height: 1.2;
   overflow-wrap: anywhere;
+  max-width: 100%;
 }
 
 .kpi .value.is-compact {
-  font-size: 1.2rem;
+  font-size: clamp(1rem, 0.9rem + 0.5vw, 1.2rem);
 }
 
 .compare {


### PR DESCRIPTION
## Summary
- arrondir les résultats affichés en euros en unités k€, M€ et Md€ en conservant le montant exact dans une info-bulle
- ajuster la taille de police des indicateurs financiers pour éviter que l'affichage ne déborde du panneau

## Testing
- not run (tests non fournis)


------
https://chatgpt.com/codex/tasks/task_e_68caa98b8fa08320bf80566ee95ba1ec