### PR TITLE
Adjust grid spacing between header and panels

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -46,7 +46,7 @@ body {
 .app-grid {
   display: grid;
   gap: var(--space-lg);
-  padding: 0 var(--space-xl) var(--space-xl);
+  padding: var(--space-md) var(--space-xl) var(--space-xl);
 }
 
 @media (min-width: 860px) {


### PR DESCRIPTION
## Summary
- replace the main grid's top margin with internal top padding so the sections sit slightly below the header without extra outer spacing

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68caad99cf7c8320a4a110eeddc942ab